### PR TITLE
Fix NPKit shutdown timing

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1966,25 +1966,10 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   int commDevice = comm->cudaDev;
   ncclResult_t ret = ncclSuccess;
 
-#if defined(ENABLE_NPKIT)
-  const char* npkitDumpDir = nullptr;
-#endif
-
   CUDACHECKGOTO(cudaGetDevice(&savedDevice), ret, fail);
   if (savedDevice != commDevice) {
     CUDACHECKGOTO(cudaSetDevice(commDevice), ret, fail);
   }
-
-#if defined(ENABLE_NPKIT)
-  // Dump NPKit events and shutdown
-  npkitDumpDir = getenv("NPKIT_DUMP_DIR");
-  if (npkitDumpDir == nullptr) {
-    WARN("NPKIT_DUMP_DIR is empty");
-  } else {
-    NCCLCHECKGOTO(NpKit::Dump(npkitDumpDir), ret, fail);
-  }
-  NCCLCHECKGOTO(NpKit::Shutdown(), ret, fail);
-#endif
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
 
@@ -2043,6 +2028,17 @@ static ncclResult_t commCleanup(ncclComm_t comm) {
   if (savedDevice != commDevice) {
     CUDACHECK(cudaSetDevice(savedDevice));
   }
+
+#if defined(ENABLE_NPKIT)
+  // Dump NPKit events and shutdown
+  const char* npkitDumpDir = getenv("NPKIT_DUMP_DIR");
+  if (npkitDumpDir == nullptr) {
+    WARN("NPKIT_DUMP_DIR is empty");
+  } else {
+    NCCLCHECK(NpKit::Dump(npkitDumpDir));
+  }
+  NCCLCHECK(NpKit::Shutdown());
+#endif
 
   if (mscclEnabled()) {
     NCCLCHECK(mscclTeardown());


### PR DESCRIPTION
Some applications like PyTorch calls ncclAbort instead of ncclDestroy, move NPKit shutdown to commCleanup to collect events for those cases.
Reference: https://github.com/ROCm/rccl/blob/develop/src/init.cc#L2529-L2538